### PR TITLE
Fix file access control on batched export downloads - broken by recent commit

### DIFF
--- a/views_data_export.module
+++ b/views_data_export.module
@@ -57,7 +57,7 @@ function views_data_export_file_download($filepath) {
  *   TRUE if the filepath identifies an export file, FALSE otherwise.
  */
 function views_data_export_is_export_file($filepath) {
-  return strpos($filepath, file_directory_temp() . '/views_plugin_display') === 0;
+  return strpos($filepath, realpath(file_directory_temp()) . '/views_plugin_display') === 0;
 }
 
 /**


### PR DESCRIPTION
The security fix b22a769a8566e750260e1a4b6bcd3189b6361932 seems to **always** return access denied even when it should allow access.

The problem is that the $filepath passed to  views_data_export_is_export_file() is an absolute system path and so the strpos check doesn't work.

Wrapping realpath() around file_directory_temp() seems to solve the issue, although I'm not sure if this is the right fix. For one thing it means that every call to hook_file_download() will need to compute the realpath of the temp dir just to compare it...

Is it even correct to pass absolute system paths to hook_file_download()? The record in the files table also contains the absolute path.

This all seems to originate [here](https://github.com/d6lts/views_data_export/blob/6.x-2.x/plugins/views_data_export_plugin_display_export.inc#L699) in views_data_export_plugin_display_export::outputfile_create()
`$path = tempnam(realpath($dir), 'views_data');`

tempnam() returns an absolute path and this ends up as the filepath on the file record and we're always dealing with an absolute path from then on..

So maybe it's better to fix it there?


