### PR TITLE
Fix PHP strict warning in _views_data_export_batch_process()

### DIFF
--- a/views_data_export.module
+++ b/views_data_export.module
@@ -184,6 +184,9 @@ function _views_data_export_batch_process($export_id, $display_id, &$context) {
   $view->set_display($display_id);
 
   // Inform the data_export display which export it corresponds to and execute
+  if (!isset($view->display_handler->batched_execution_state)) {
+    $view->display_handler->batched_execution_state = new stdClass();
+  }
   $view->display_handler->batched_execution_state->eid = $export_id;
   $view->execute_display($display_id);
 


### PR DESCRIPTION
I have cherry-picked [710010816f30317b969eac9b7e520e3bccf7db24](https://git.drupalcode.org/project/views_data_export/-/commit/710010816f30317b969eac9b7e520e3bccf7db24) from the official drupal.org repo.

This commit originally went into 7.x-3.x as a fix for issue [#1354590](https://www.drupal.org/project/views_data_export/issues/1354590) "PHP strict warning in _views_data_export_batch_process()"

It fixes a php warning "Creating default object from empty value in _views_data_export_batch_process()"

