### PR TITLE
Allow configuring # processed per batch - (Issue #1592098)

### DIFF
--- a/plugins/views_data_export_plugin_display_export.inc
+++ b/plugins/views_data_export_plugin_display_export.inc
@@ -61,6 +61,9 @@ class views_data_export_plugin_display_export extends views_plugin_display_feed 
     $options['items_per_page'] = array('default' => '0');
     $options['style_plugin']['default'] = 'views_data_export_csv';
 
+    // This is the default size of a segment when doing a batched export.
+    $options['segment_size']['default'] = 100;
+
     if (isset($options['defaults']['default']['items_per_page'])) {
       $options['defaults']['default']['items_per_page'] = FALSE;
     }
@@ -109,6 +112,18 @@ class views_data_export_plugin_display_export extends views_plugin_display_feed 
             FALSE => t('Export data all in one segment. Possible time and memory limit issues.'),
           ),
         );
+        // Allow the administrator to configure the number of items exported per batch.
+        $form['segment_size'] = array(
+          '#type' => 'select',
+          '#title' => t('Segment size'),
+          '#description' => t('If each row of your export consumes a lot of memory to render, then reduce this value. Higher values will generally mean that the export completes in less time but will have a higher peak memory usage.'),
+          '#options' => drupal_map_assoc(range(1, 500)),
+          '#default_value' => $this->get_option('segment_size'),
+          '#process' => array('views_process_dependency'),
+          '#dependency' => array(
+            'radio:use_batch' => array(TRUE),
+          ),
+        );
         if (!$this->is_compatible()) {
           $form['use_batch']['#disabled'] = TRUE;
           $form['use_batch']['#default_value'] = 0;
@@ -131,6 +146,7 @@ class views_data_export_plugin_display_export extends views_plugin_display_feed 
     switch ($form_state['section']) {
       case 'use_batch':
         $this->set_option('use_batch', $form_state['values']['use_batch']);
+        $this->set_option('segment_size', $form_state['values']['segment_size']);
         break;
     }
   }
@@ -414,7 +430,7 @@ class views_data_export_plugin_display_export extends views_plugin_display_feed 
           $this->view->executed = TRUE;
           // Grab our results from the index, and push them into the view result.
           // TODO: Handle external databases.
-          $result = db_query_range('SELECT * FROM {' . $this->index_tablename() . '} ORDER BY ' . $this->batched_execution_state->sandbox['weight_field_alias'] . ' ASC', 0, 100);
+          $result = db_query_range('SELECT * FROM {' . $this->index_tablename() . '} ORDER BY ' . $this->batched_execution_state->sandbox['weight_field_alias'] . ' ASC', 0, $this->get_option('segment_size'));
           $this->view->result = array();
           while ($item_arr = db_fetch_array($result)) {
             $item = new stdClass();


### PR DESCRIPTION
Currently 6.x-3.x still hardcodes processing 100 items per batch refresh.
This commit allows that to be configured, and was already included in 6.x-2.x, but never went into 6.x-3.x.

[Issue #1592098 by Steven Jones: Fixed items_per_page() not respected via batch export.](https://git.drupalcode.org/project/views_data_export/-/commit/74f9984bd995cd56596240a4584d2110de87ab24)

Note: It appears there are several fixes that went into 6.x-2.x without going into 6.x-3.x.
I hope to file some more pull requests if I have any time to review them.